### PR TITLE
armhf: update to bullseye to bump cmake version

### DIFF
--- a/armhf/Dockerfile
+++ b/armhf/Dockerfile
@@ -1,10 +1,8 @@
 # this image should be created with name cuberite/ci-armhf
-FROM debian:buster
+FROM debian:bullseye
 
 # Install required software
 RUN apt-get update && apt-get install -y --no-install-recommends \
-	gcc-arm-linux-gnueabihf \
-	g++-arm-linux-gnueabihf \
 	cmake \
 	git \
 	lua5.1 \


### PR DESCRIPTION
CMake 3.13.4 on Buster: http://builds.cuberite.org/job/linux-armhf/267/consoleText
Issue reproduced locally. Manually downloading and using CMake 3.18.4 (still on Buster) makes the problem go away with nothing else changed.

Upgrade to Bullseye to get 3.18.4.